### PR TITLE
[CHORE] Fixes issue with gpr publish

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -4,9 +4,8 @@
 name: Node.js Package
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -29,11 +28,20 @@ jobs:
           node-version: 12
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+        # This will tell npm to publish your scoped package with public access.
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
+
+  # Disabled job
   publish-gpr:
+    # This doesn't work and read
+    # https://github.com/actions/setup-node/issues/73#issuecomment-599199211
+    # to know why. Github package repository doens't work for package
+    # which are not scoped hence not publishing
+    # Hence, disabling it
+    if: 1 == 0
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -42,8 +50,10 @@ jobs:
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
-          scope: "@amzn"
       - run: npm ci
+        # Read https://joeattardi.codes/2019-11-16-github-package/ to know more
+        # about this hack. I think the above issue should explain this
+      - run: echo registry=https://npm.pkg.github.com/amzn >> $NPM_CONFIG_USERCONFIG
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-commit-template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-commit-template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set commit template for git packages",
   "bin": {
     "git-commit-template": "./bin/git-commit-template.js"


### PR DESCRIPTION
Removed scope as that will be automatically read based on org.

Disabled the gpr publish as this doesn't work for non-scoped packages.

Added public access to npm publish command for npm registry

[TESTING]

Tested this by running builds on github actions

closes: N/A

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
