### PR TITLE
[BUG] Fixes push on tag publish

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -38,4 +38,4 @@ jobs:
           #CI_USER: "CHANGELOG Bot"
           #CI_EMAIL: "noreply@github.com"
         run: |
-          git push
+          git push origin HEAD:master

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![npm
 publish](https://github.com/amzn/git-commit-template/workflows/publish/badge.svg)
+![changelog](https://github.com/amzn/git-commit-template/workflows/changelog/badge.svg)
 
 Sets commit template for your git projects. This is a husky plugin which should
 be used on `prepare-commit-msg` hook exposed by git.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-commit-template",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Set commit template for git packages",
   "bin": {
     "git-commit-template": "./bin/git-commit-template.js"


### PR DESCRIPTION
In case of tag publish we move to detached state which was failing the
git push. Updated the command to work on tag publishing too.

Bumped the version to `1.0.4` to safely publish this to npm

[TESTING]

Tested with my forked repo

closes: https://github.com/amzn/git-commit-template/issues/11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
