### PR TITLE
[BUG] Fixs changelog for pull_request close event

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Generate changelog
         uses: charmixer/auto-changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit files
         env:
@@ -33,9 +35,8 @@ jobs:
       - name: Push changes
         # This will be true if we are able to commit changes
         if: env.push == 1
-        #env:
-          # Do we need this again or it picks from top
-          #CI_USER: "CHANGELOG Bot"
-          #CI_EMAIL: "noreply@github.com"
+        env:
+          CI_USER: "CHANGELOG Bot"
+          CI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin HEAD:master
+          git push "https://$CI_USER:$CI_TOKEN@github.com/$GITHUB_REPOSITORY.git" HEAD:master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-commit-template",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-commit-template",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Set commit template for git packages",
   "bin": {
     "git-commit-template": "./bin/git-commit-template.js"


### PR DESCRIPTION
When pull request was getting merged we were getting error in changelog
generation workflow as permissions error. Updated the push command to
use secrets.GITHUB_TOKEN to push. It also has other benefits of not
triggering the actions again. Read more at:
https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#using-the-github_token-in-a-workflow

Bumped package.json version to `1.0.5`

[TESTING]

Tested with my forked repo

closes: https://github.com/amzn/git-commit-template/issues/11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
